### PR TITLE
Add module autoloading and udev rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,8 @@ pts/tty0tty
 .pydevproject
 
 # debian packaging artifacts
-debian/*
+debian/.debhelper/
+debian/tty0tty-dkms/
 debhelper/*
 files
 *-dkms.debhelper.log

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,0 +1,40 @@
+#!/bin/sh
+set -e
+# Automatically added by dh_dkms/3.0.10-8+deb12u1
+# The original file can be found in template-dkms-mkdeb/debian/postinst
+# in the DKMS tarball, check it for copyright notices.
+
+DKMS_NAME=tty0tty
+DKMS_PACKAGE_NAME=$DKMS_NAME-dkms
+DKMS_VERSION=1.2+viv1
+
+postinst_found=0
+
+case "$1" in
+	configure)
+		for DKMS_POSTINST in /usr/lib/dkms/common.postinst /usr/share/$DKMS_PACKAGE_NAME/postinst; do
+			if [ -f $DKMS_POSTINST ]; then
+				$DKMS_POSTINST $DKMS_NAME $DKMS_VERSION /usr/share/$DKMS_PACKAGE_NAME "" $2
+				postinst_found=1
+				break
+			fi
+		done
+		if [ "$postinst_found" -eq 0 ]; then
+			echo "ERROR: DKMS version is too old and $DKMS_PACKAGE_NAME was not"
+			echo "built with legacy DKMS support."
+			echo "You must either rebuild $DKMS_PACKAGE_NAME with legacy postinst"
+			echo "support or upgrade DKMS to a more current version."
+			exit 1
+		fi
+        # Load the tty0tty kernel module immediately
+        if ! lsmod | grep -q tty0tty; then
+            modprobe tty0tty
+        fi
+        # Ensure the module loads on boot
+        if ! grep -q "^tty0tty$" /etc/modules-load.d/tty0tty.conf; then
+            echo tty0tty >> /etc/modules-load.d/tty0tty.conf
+        fi
+	;;
+esac
+# End automatically added section
+exit 0

--- a/debian/rules
+++ b/debian/rules
@@ -7,6 +7,7 @@ VERSION=$(shell dpkg-parsechangelog |grep ^Version:|cut -d ' ' -f 2)
 
 override_dh_install:
 	dh_install module/Makefile module/tty0tty.c usr/src/tty0tty-$(VERSION)/
+	dh_install module/50-tty0tty.rules etc/udev/rules.d/
 
 override_dh_dkms:
 	dh_dkms -V $(VERSION)


### PR DESCRIPTION
Hello!

We are using your combined-fix branch and found it very helpful. We made some additional changes:

- Include the udev rules in the Debian package (they are in the repository but not part of the package)
- Add a post install script to the package that sets up the module to be autoloaded at boot, and load it when installing (since it is not related to any specific hardware, the kernel will not autoload it otherwise).

I will also submit these changes upstream to freemed, but, since the repository seems a bit inactive, it would be nice if we could keep a single branch with all the fixes.